### PR TITLE
Add Ethereum 2.0 Deposit Contract

### DIFF
--- a/abis/DepositContract.json
+++ b/abis/DepositContract.json
@@ -1,0 +1,130 @@
+[
+	{
+		"inputs": [],
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"internalType": "bytes32",
+				"name": "data",
+				"type": "bytes32"
+			}
+		],
+		"name": "Debug",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"internalType": "bytes",
+				"name": "pubkey",
+				"type": "bytes"
+			},
+			{
+				"indexed": false,
+				"internalType": "bytes",
+				"name": "withdrawal_credentials",
+				"type": "bytes"
+			},
+			{
+				"indexed": false,
+				"internalType": "bytes",
+				"name": "amount",
+				"type": "bytes"
+			},
+			{
+				"indexed": false,
+				"internalType": "bytes",
+				"name": "signature",
+				"type": "bytes"
+			},
+			{
+				"indexed": false,
+				"internalType": "bytes",
+				"name": "index",
+				"type": "bytes"
+			}
+		],
+		"name": "DepositEvent",
+		"type": "event"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "bytes",
+				"name": "pubkey",
+				"type": "bytes"
+			},
+			{
+				"internalType": "bytes",
+				"name": "withdrawal_credentials",
+				"type": "bytes"
+			},
+			{
+				"internalType": "bytes",
+				"name": "signature",
+				"type": "bytes"
+			},
+			{
+				"internalType": "bytes32",
+				"name": "deposit_data_root",
+				"type": "bytes32"
+			}
+		],
+		"name": "deposit",
+		"outputs": [],
+		"stateMutability": "payable",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "get_deposit_count",
+		"outputs": [
+			{
+				"internalType": "bytes",
+				"name": "",
+				"type": "bytes"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"name": "get_deposit_root",
+		"outputs": [
+			{
+				"internalType": "bytes32",
+				"name": "",
+				"type": "bytes32"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "bytes4",
+				"name": "interfaceId",
+				"type": "bytes4"
+			}
+		],
+		"name": "supportsInterface",
+		"outputs": [
+			{
+				"internalType": "bool",
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"stateMutability": "pure",
+		"type": "function"
+	}
+]

--- a/config/instances.json
+++ b/config/instances.json
@@ -55,5 +55,7 @@
   },
   "SkaleValidatorService": {
     "default": "0x840C8122433A5AA7ad60C1Bcdc36AB9DcCF761a5"
+  },
+  "DepositContract": {
   }
 }

--- a/examples/DepositContract/deposit.ts
+++ b/examples/DepositContract/deposit.ts
@@ -1,0 +1,17 @@
+import { Contract } from '../../src/contract';
+
+const depositContractAddress = '0x'; // this is not yet known
+const validatorKey = '0x0000';
+const withdrawalKey = '0x0000';
+const signature = '0x0000';
+const depositDataRoot = '0x0000';
+
+const depositContract = new Contract('DepositContract').address(depositContractAddress);
+
+let { data, amount, address } = depositContract.methods()
+  .deposit.call({ pubkey: validatorKey, withdrawal_credentials: withdrawalKey, signature: signature, deposit_data_root: depositDataRoot });
+
+console.log(`\nTo deposit into the ETH2.0 deposit contract with validator key ${validatorKey}, withdrawalKey: ${withdrawalKey}, signature: ${signature}, depositDataRoot: ${depositDataRoot}, send:`);
+console.log(`Data: ${data}`);
+console.log(`Amount: ${amount} ETH`);
+console.log(`To: ${address}`);


### PR DESCRIPTION
This commit adds the ABI and an example for the Ethereum 2.0 deposit
contract. This call enables users to transfer their ETH1 to ETH2 and
begin validating. The actual contract address is not yet known, so we
will need to fill that in once it is.

CLOSES TICKET: BG-25014