### PR TITLE
Add support for BitGo wallet contracts

### DIFF
--- a/abis/Forwarder.json
+++ b/abis/Forwarder.json
@@ -1,0 +1,264 @@
+[
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "toAddress",
+				"type": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256"
+			},
+			{
+				"name": "tokenContractAddress",
+				"type": "address"
+			},
+			{
+				"name": "expireTime",
+				"type": "uint256"
+			},
+			{
+				"name": "sequenceId",
+				"type": "uint256"
+			},
+			{
+				"name": "signature",
+				"type": "bytes"
+			}
+		],
+		"name": "sendMultiSigToken",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"name": "signers",
+		"outputs": [
+			{
+				"name": "",
+				"type": "address"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "forwarderAddress",
+				"type": "address"
+			},
+			{
+				"name": "tokenContractAddress",
+				"type": "address"
+			}
+		],
+		"name": "flushForwarderTokens",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "toAddress",
+				"type": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256"
+			},
+			{
+				"name": "data",
+				"type": "bytes"
+			},
+			{
+				"name": "expireTime",
+				"type": "uint256"
+			},
+			{
+				"name": "sequenceId",
+				"type": "uint256"
+			},
+			{
+				"name": "signature",
+				"type": "bytes"
+			}
+		],
+		"name": "sendMultiSig",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "signer",
+				"type": "address"
+			}
+		],
+		"name": "isSigner",
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "getNextSequenceId",
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "createForwarder",
+		"outputs": [
+			{
+				"name": "",
+				"type": "address"
+			}
+		],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "safeMode",
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "activateSafeMode",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"name": "allowedSigners",
+				"type": "address[]"
+			}
+		],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	},
+	{
+		"payable": true,
+		"stateMutability": "payable",
+		"type": "fallback"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"name": "from",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"name": "value",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"name": "data",
+				"type": "bytes"
+			}
+		],
+		"name": "Deposited",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"name": "msgSender",
+				"type": "address"
+			}
+		],
+		"name": "SafeModeActivated",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"name": "msgSender",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"name": "otherSigner",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"name": "operation",
+				"type": "bytes32"
+			},
+			{
+				"indexed": false,
+				"name": "toAddress",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"name": "value",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"name": "data",
+				"type": "bytes"
+			}
+		],
+		"name": "Transacted",
+		"type": "event"
+	}
+]

--- a/abis/WalletSimple.json
+++ b/abis/WalletSimple.json
@@ -1,0 +1,264 @@
+[
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "toAddress",
+				"type": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256"
+			},
+			{
+				"name": "tokenContractAddress",
+				"type": "address"
+			},
+			{
+				"name": "expireTime",
+				"type": "uint256"
+			},
+			{
+				"name": "sequenceId",
+				"type": "uint256"
+			},
+			{
+				"name": "signature",
+				"type": "bytes"
+			}
+		],
+		"name": "sendMultiSigToken",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"name": "signers",
+		"outputs": [
+			{
+				"name": "",
+				"type": "address"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "forwarderAddress",
+				"type": "address"
+			},
+			{
+				"name": "tokenContractAddress",
+				"type": "address"
+			}
+		],
+		"name": "flushForwarderTokens",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "toAddress",
+				"type": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256"
+			},
+			{
+				"name": "data",
+				"type": "bytes"
+			},
+			{
+				"name": "expireTime",
+				"type": "uint256"
+			},
+			{
+				"name": "sequenceId",
+				"type": "uint256"
+			},
+			{
+				"name": "signature",
+				"type": "bytes"
+			}
+		],
+		"name": "sendMultiSig",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "signer",
+				"type": "address"
+			}
+		],
+		"name": "isSigner",
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "getNextSequenceId",
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "createForwarder",
+		"outputs": [
+			{
+				"name": "",
+				"type": "address"
+			}
+		],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "safeMode",
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [],
+		"name": "activateSafeMode",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"name": "allowedSigners",
+				"type": "address[]"
+			}
+		],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	},
+	{
+		"payable": true,
+		"stateMutability": "payable",
+		"type": "fallback"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"name": "from",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"name": "value",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"name": "data",
+				"type": "bytes"
+			}
+		],
+		"name": "Deposited",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"name": "msgSender",
+				"type": "address"
+			}
+		],
+		"name": "SafeModeActivated",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"name": "msgSender",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"name": "otherSigner",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"name": "operation",
+				"type": "bytes32"
+			},
+			{
+				"indexed": false,
+				"name": "toAddress",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"name": "value",
+				"type": "uint256"
+			},
+			{
+				"indexed": false,
+				"name": "data",
+				"type": "bytes"
+			}
+		],
+		"name": "Transacted",
+		"type": "event"
+	}
+]

--- a/config/instances.json
+++ b/config/instances.json
@@ -57,5 +57,9 @@
     "default": "0x840C8122433A5AA7ad60C1Bcdc36AB9DcCF761a5"
   },
   "DepositContract": {
+  },
+  "Forwarder": {
+  },
+  "WalletSimple": {
   }
 }

--- a/examples/DepositContract/deposit.ts
+++ b/examples/DepositContract/deposit.ts
@@ -8,7 +8,7 @@ const depositDataRoot = '0x0000';
 
 const depositContract = new Contract('DepositContract').address(depositContractAddress);
 
-let { data, amount, address } = depositContract.methods()
+const { data, amount, address } = depositContract.methods()
   .deposit.call({ pubkey: validatorKey, withdrawal_credentials: withdrawalKey, signature: signature, deposit_data_root: depositDataRoot });
 
 console.log(`\nTo deposit into the ETH2.0 deposit contract with validator key ${validatorKey}, withdrawalKey: ${withdrawalKey}, signature: ${signature}, depositDataRoot: ${depositDataRoot}, send:`);

--- a/src/decoder/types.ts
+++ b/src/decoder/types.ts
@@ -1,4 +1,5 @@
 import { bufferToHex, bufferToInt, addHexPrefix } from 'ethereumjs-util';
+import BigNumber from 'bignumber.js';
 import { ensure } from '../util/ensure';
 
 enum Primitive {
@@ -81,7 +82,9 @@ export function formatValue(value: any, type: string): any {
       case Primitive.Bytes:
         return bufferToHex(value);
       case Primitive.Int:
-        return bufferToInt(value);
+        // value is a Buffer
+        const bigNumberValue = new BigNumber(value.toString('hex'), 16);
+        return bigNumberValue.toFixed();
       case Primitive.String:
         return value.toString();
     }

--- a/test/decoder/index.ts
+++ b/test/decoder/index.ts
@@ -16,7 +16,7 @@ const testCases: TestCase[] = [
       methodId: '0xa9059cbb',
       args: [
         { name: '_to', type: 'address', value: '0x10d4f942617a231eb1430c88fe43c8c2050437d9' },
-        { name: '_value', type: 'uint256', value: 10000 },
+        { name: '_value', type: 'uint256', value: '10000' },
       ],
     },
   },
@@ -39,6 +39,27 @@ const testCases: TestCase[] = [
       methodId: '0xeb0dff66',
       args: [
         { name: 'dst', type: 'address', value: '0xf7aba9b064a12330a00eafaa930e2fe8e76e65f0' },
+      ],
+    },
+  },
+  {
+    data: '0x39125215000000000000000000000000b19fb72b55f5374a062ddcba874e566b1d93f5d3000000000000000000000000000000000000000000000000016345785d8a000000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000005f7cde11000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000416508bd6fc3da79ff7e5b84ff79f50e48112579d7b5190caeb92fd7cb4d2ac0f362f431480770e9bbe7e1437d7c21b49a64e03e5f1cfb0eaf3f84f2435b972fdc1b00000000000000000000000000000000000000000000000000000000000000',
+    expected: {
+      contractName: 'WalletSimple',
+      name: 'sendMultiSig',
+      methodId: '0x39125215',
+      args: [
+        { name: 'toAddress',
+          type: 'address',
+          value: '0xb19fb72b55f5374a062ddcba874e566b1d93f5d3' },
+        { name: 'value', type: 'uint256', value: '100000000000000000' },
+        { name: 'data', type: 'bytes', value: '0x' },
+        { name: 'expireTime', type: 'uint256', value: '1602018833' },
+        { name: 'sequenceId', type: 'uint256', value: '1' },
+        { name: 'signature',
+          type: 'bytes',
+          value:
+                '0x6508bd6fc3da79ff7e5b84ff79f50e48112579d7b5190caeb92fd7cb4d2ac0f362f431480770e9bbe7e1437d7c21b49a64e03e5f1cfb0eaf3f84f2435b972fdc1b' },
       ],
     },
   },

--- a/test/testutil.ts
+++ b/test/testutil.ts
@@ -1,16 +1,17 @@
 import { ensure } from '../src/util/ensure';
+import BigNumber from 'bignumber.js';
 
-const generateInteger = (max: number) => {
-  return () => {
-    return Math.floor(Math.random() * max);
+const generateNumber = (max: number) => {
+  return (): string => {
+    return BigNumber.random(18).times(max).integerValue(BigNumber.ROUND_FLOOR).toString(10);
   };
 };
 
 const generateSignedInteger = (max: number) => {
-  return () => {
-    const unsigned = generateInteger(max)();
-    const sign = generateInteger(2)();
-    return sign ? unsigned : -1 * unsigned;
+  return (): string => {
+    const unsigned = generateNumber(max)();
+    const sign = generateNumber(2)();
+    return sign ? unsigned : (new BigNumber(unsigned).times(-1)).toString(10);
   };
 };
 
@@ -19,7 +20,7 @@ const generateHexString = (length: number): () => string => {
     ensure(length % 2 === 0, `Invalid hex length: ${length}`);
     let result = '0x';
     for (let i = 0; i < length / 2; i++) {
-      const byte = generateInteger(256)();
+      const byte = new BigNumber(generateNumber(256)());
       result += byte.toString(16);
     }
     return result;
@@ -38,30 +39,28 @@ const generateHexStringArray = (strLength: number, arrLength: number): () => str
 
 const generateFromOptions = (options: any[]) => {
   return () => {
-    return options[generateInteger(options.length)()];
+    return options[parseInt(generateNumber(options.length)())];
   };
 };
 
 const solidityTypes: { [key: string]: any } = {
-  uint: generateInteger(2e8),
-  uint8: generateInteger(2e8),
-  uint16: generateInteger(2e8),
-  uint32: generateInteger(2e8),
-  uint64: generateInteger(2e8),
-  uint128: generateInteger(2e8),
-  uint256: generateInteger(2e8),
+  uint: generateNumber(2e8),
+  uint8: generateNumber(2e2),
+  uint16: generateNumber(2e4),
+  uint32: generateNumber(2e8),
+  uint64: generateNumber(2e8),
+  uint128: generateNumber(2e8),
+  uint256: generateNumber(2e16),
   int256: generateSignedInteger(2e8),
   bool: generateFromOptions([true, false]),
   address: generateHexString(40),
   bytes: generateHexString(32),
-  byte: generateHexString(2),
-  byte1: generateHexString(2),
-  byte2: generateHexString(4),
-  byte3: generateHexString(6),
-  byte4: generateHexString(8),
-  byte8: generateHexString(16),
-  byte16: generateHexString(32),
-  byte32: generateHexString(64),
+  bytes1: generateHexString(2),
+  bytes2: generateHexString(4),
+  bytes3: generateHexString(6),
+  bytes4: generateHexString(8),
+  bytes8: generateHexString(16),
+  bytes16: generateHexString(32),
   bytes32: generateHexString(64),
   string: generateFromOptions(['asdfadsf', 'hello world', 'test']),
   ['address[]']: generateHexStringArray(40, 1),


### PR DESCRIPTION
This commit adds support for bitgo wallet contracts, and fixes the tests
to actually pass for contracts that accept large numbers (by using
bignumbers and string numbers instead of js numbers)

CLOSES TICKET: BG-25245